### PR TITLE
Don't use lowercase Qt keywords in public headers

### DIFF
--- a/include/kImageAnnotator/KImageAnnotator.h
+++ b/include/kImageAnnotator/KImageAnnotator.h
@@ -45,7 +45,7 @@ public:
 	void showCropper();
 	void showScaler();
 
-public slots:
+public Q_SLOTS:
 	void loadImage(const QPixmap &pixmap);
 	int addImage(const QPixmap &pixmap, const QString &title, const QString &toolTip);
 	void updateTabInfo(int index, const QString &title, const QString &toolTip);
@@ -59,7 +59,7 @@ public slots:
 	void setTabBarAutoHide(bool enabled);
 	void removeTab(int index);
 
-signals:
+Q_SIGNALS:
 	void imageChanged() const;
 	void currentTabChanged(int index) const;
 	void tabCloseRequested(int index) const;


### PR DESCRIPTION
Lower case keywords should be avoided since they can break other code. Replace them at least in the header that gets included in other programs