### PR TITLE
Make link against X11 and kcolorpicker private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ target_include_directories(kImageAnnotator
 target_link_libraries(kImageAnnotator PUBLIC Qt5::Widgets Qt5::Svg kColorPicker::kColorPicker)
 
 if (UNIX AND NOT APPLE)
-	target_link_libraries(kImageAnnotator PUBLIC X11)
+	target_link_libraries(kImageAnnotator PRIVATE X11)
 endif ()
 
 target_compile_definitions(kImageAnnotator PRIVATE KIMAGEANNOTATOR_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(kImageAnnotator
 						   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 						   )
 
-target_link_libraries(kImageAnnotator PUBLIC Qt5::Widgets Qt5::Svg kColorPicker::kColorPicker)
+target_link_libraries(kImageAnnotator PUBLIC Qt5::Widgets Qt5::Svg PRIVATE kColorPicker::kColorPicker)
 
 if (UNIX AND NOT APPLE)
 	target_link_libraries(kImageAnnotator PRIVATE X11)


### PR DESCRIPTION
It is not used in public headers so we don't need to mark the link as public.

This saves users of the API from searching for X11 and kcolorpicker