### PR TITLE
Update displayed properties  on item deselected / removed

### DIFF
--- a/src/annotations/core/AnnotationArea.cpp
+++ b/src/annotations/core/AnnotationArea.cpp
@@ -44,6 +44,7 @@ AnnotationArea::AnnotationArea(Config *config, AbstractSettingsProvider *setting
 
 	connect(mItemModifier, &AnnotationItemModifier::newCommand, mUndoStack, &UndoStack::push);
 	connect(mItemModifier, &AnnotationItemModifier::itemsSelected, this, &AnnotationArea::itemsSelected);
+	connect(mItemModifier, &AnnotationItemModifier::itemsDeselected, this, &AnnotationArea::itemsDeselected);
 	connect(mItemModifier, &AnnotationItemModifier::itemModified, this, &AnnotationArea::imageChanged);
 	connect(mUndoStack, &UndoStack::indexChanged, this, &AnnotationArea::update);
 	connect(mKeyHelper, &KeyHelper::deleteReleased, this, &AnnotationArea::deleteSelectedItems);
@@ -343,6 +344,11 @@ void AnnotationArea::itemsSelected(const QList<AbstractAnnotationItem *> &items)
 	}
 	auto item = items.first();
 	mSettingsProvider->editItem(item);
+}
+
+void AnnotationArea::itemsDeselected()
+{
+	mSettingsProvider->activateSelectTool();
 }
 
 void AnnotationArea::dragMoveEvent(QGraphicsSceneDragDropEvent *event)

--- a/src/annotations/core/AnnotationArea.cpp
+++ b/src/annotations/core/AnnotationArea.cpp
@@ -309,6 +309,9 @@ void AnnotationArea::deleteSelectedItems()
 	auto selectedItems = mItemModifier->selectedItems();
 	mItemModifier->clear();
 	mUndoStack->push(new DeleteCommand(selectedItems, this));
+	if (mSettingsProvider->toolType() == Tools::Select) {
+		mSettingsProvider->activateSelectTool();
+	}
 }
 
 void AnnotationArea::pasteCopiedItems(const QPointF &position)

--- a/src/annotations/core/AnnotationArea.h
+++ b/src/annotations/core/AnnotationArea.h
@@ -114,6 +114,7 @@ private slots:
     void enableEditing();
     EditableItem* selectedEditableItem() const;
 	void itemsSelected(const QList<AbstractAnnotationItem *> &items) const;
+	void itemsDeselected();
 };
 
 } // namespace kImageAnnotator

--- a/src/annotations/modifiers/AnnotationItemModifier.cpp
+++ b/src/annotations/modifiers/AnnotationItemModifier.cpp
@@ -148,9 +148,9 @@ void AnnotationItemModifier::handleSelection()
 	if (count == 0) {
 		clear();
 	} else {
-		mItemResizer->attachTo(selectedItems);
-		emit itemsSelected(selectedItems);
+        mItemResizer->attachTo(selectedItems);
 	}
+	emit itemsSelected(selectedItems);
 }
 
 void AnnotationItemModifier::updateCursor(Qt::CursorShape cursor)

--- a/src/annotations/modifiers/AnnotationItemModifier.cpp
+++ b/src/annotations/modifiers/AnnotationItemModifier.cpp
@@ -148,7 +148,7 @@ void AnnotationItemModifier::handleSelection()
 	if (count == 0) {
 		clear();
 	} else {
-        mItemResizer->attachTo(selectedItems);
+		mItemResizer->attachTo(selectedItems);
 	}
 	emit itemsSelected(selectedItems);
 }

--- a/src/annotations/modifiers/AnnotationItemModifier.cpp
+++ b/src/annotations/modifiers/AnnotationItemModifier.cpp
@@ -147,10 +147,11 @@ void AnnotationItemModifier::handleSelection()
 	auto count = selectedItems.count();
 	if (count == 0) {
 		clear();
+		emit itemsDeselected();
 	} else {
 		mItemResizer->attachTo(selectedItems);
+		emit itemsSelected(selectedItems);
 	}
-	emit itemsSelected(selectedItems);
 }
 
 void AnnotationItemModifier::updateCursor(Qt::CursorShape cursor)

--- a/src/annotations/modifiers/AnnotationItemModifier.h
+++ b/src/annotations/modifiers/AnnotationItemModifier.h
@@ -51,6 +51,7 @@ public slots:
 signals:
 	void newCommand(QUndoCommand *command);
 	void itemsSelected(const QList<AbstractAnnotationItem *> &items) const;
+	void itemsDeselected();
 	void itemModified() const;
 
 protected:


### PR DESCRIPTION
Issue: https://github.com/ksnip/ksnip/issues/482

As shown in screenshot:
- Selection tool is selected
- No item is selected
- The properties of the previously selected item (currently deleted) are displayed

![image](https://user-images.githubusercontent.com/73212737/99786862-abbde580-2b27-11eb-986d-01605b582b52.png)
