### PR TITLE
Add function for loading translations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ if (UNIX AND NOT APPLE)
 endif ()
 
 target_compile_definitions(kImageAnnotator PRIVATE KIMAGEANNOTATOR_LIB)
+target_compile_definitions(kImageAnnotator PRIVATE KIMAGEANNOTATOR_LANG_INSTALL_DIR="${KIMAGEANNOTATOR_LANG_INSTALL_DIR}")
 
 set_target_properties(kImageAnnotator
 					  PROPERTIES

--- a/include/kImageAnnotator/KImageAnnotator.h
+++ b/include/kImageAnnotator/KImageAnnotator.h
@@ -26,6 +26,8 @@
 
 namespace kImageAnnotator {
 
+KIMAGEANNOTATOR_EXPORT void loadTranslations();
+
 class KImageAnnotatorPrivate;
 
 class KIMAGEANNOTATOR_EXPORT KImageAnnotator : public QWidget

--- a/src/gui/KImageAnnotator.cpp
+++ b/src/gui/KImageAnnotator.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <QCoreApplication>
+#include <QTranslator>
 #include <QHBoxLayout>
 
 #include <kImageAnnotator/KImageAnnotator.h>
@@ -30,6 +31,22 @@ inline void initResource()
 }
 
 namespace kImageAnnotator {
+
+void loadTranslations()
+{
+	static QTranslator *currentTranslator = nullptr;
+	auto translator = new QTranslator(QCoreApplication::instance());
+	if (translator->load(QLocale(), QLatin1String("kImageAnnotator"),
+	                                QLatin1String("_"),
+	                                QLatin1String(KIMAGEANNOTATOR_LANG_INSTALL_DIR))) {
+		if (currentTranslator) {
+			QCoreApplication::removeTranslator(currentTranslator);
+			delete currentTranslator;
+		}
+		QCoreApplication::installTranslator(translator);
+		currentTranslator = translator;
+	}
+}
 
 class KImageAnnotatorPrivate
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,8 @@ add_library(KIMAGEANNOTATOR_STATIC STATIC ${KIMAGEANNOTATOR_SRCS})
 
 target_link_libraries(KIMAGEANNOTATOR_STATIC Qt5::Widgets Qt5::Svg kImageAnnotator)
 
+target_compile_definitions(KIMAGEANNOTATOR_STATIC PRIVATE KIMAGEANNOTATOR_LANG_INSTALL_DIR="${KIMAGEANNOTATOR_LANG_INSTALL_DIR}")
+
 foreach (UnitTest ${UNITTEST_SRC})
 	get_filename_component(UnitTestName ${UnitTest} NAME_WE)
 	add_executable(${UnitTestName} ${UnitTest} ${TESTUTILS_SRC})


### PR DESCRIPTION
It's more logical for the library than for user code to know
where the library's translations are located and how to load them.