### PR TITLE
Add override where it is missing

### DIFF
--- a/include/kImageAnnotator/KImageAnnotator.h
+++ b/include/kImageAnnotator/KImageAnnotator.h
@@ -43,7 +43,7 @@ public:
 	QImage imageAt(int index) const;
 	QAction *undoAction();
 	QAction *redoAction();
-	QSize sizeHint() const;
+	QSize sizeHint() const override;
 	void showAnnotator();
 	void showCropper();
 	void showScaler();

--- a/src/annotations/core/AnnotationArea.h
+++ b/src/annotations/core/AnnotationArea.h
@@ -68,7 +68,7 @@ public:
     virtual void scale(const QSize& size);
     virtual void clearSelection();
 	virtual void toolChanged(Tools toolType) override;
-	void itemSettingsChanged();
+	void itemSettingsChanged() override;
 	void numberToolSeedChanged(int numberToolSeed) override;
 	int numberToolSeed() const override;
 	void imageEffectChanged(ImageEffects effect) override;

--- a/src/gui/CoreView.h
+++ b/src/gui/CoreView.h
@@ -40,7 +40,7 @@ public:
 	QImage imageAt(int index) const;
 	QAction *undoAction();
 	QAction *redoAction();
-	QSize sizeHint() const;
+	QSize sizeHint() const override;
 	void reloadConfig();
 
 signals:


### PR DESCRIPTION
`override` is specified in most places where it is needed (with Clang and the default settings, prints a warning), but there's a couple missing.