### PR TITLE
Remove latin1literal

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -32,8 +32,8 @@ int main(int argc, char **argv)
 	QPixmap pixmap(QSize(500, 500));
 	pixmap.fill(QColor(Qt::darkGreen));
 	auto kImageAnnotator = new KImageAnnotator();
-	kImageAnnotator->addTab(pixmap, QLatin1Literal("image1"), QLatin1Literal("image1"));
-	kImageAnnotator->addTab(pixmap, QLatin1Literal("image2"), QLatin1Literal("image2"));
+	kImageAnnotator->addTab(pixmap, QStringLiteral("image1"), QStringLiteral("image1"));
+	kImageAnnotator->addTab(pixmap, QStringLiteral("image2"), QStringLiteral("image2"));
 	kImageAnnotator->adjustSize();
 
 	QMainWindow mainWindow;

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -39,11 +39,11 @@ int main(int argc, char **argv)
 	QMainWindow mainWindow;
 	mainWindow.setCentralWidget(kImageAnnotator);
 	auto menuBar = mainWindow.menuBar();
-	auto menu = new QMenu(QLatin1Literal("Edit"));
-	auto annotationAction = new QAction(QLatin1Literal("Annotation"), &mainWindow);
-	auto cropAction = new QAction(QLatin1Literal("Crop"), &mainWindow);
-	auto scaleAction = new QAction(QLatin1Literal("Scale"), &mainWindow);
-	auto modifyCanvasAction = new QAction(QLatin1Literal("Modify Canvas"), &mainWindow);
+	auto menu = new QMenu(QStringLiteral("Edit"));
+	auto annotationAction = new QAction(QStringLiteral("Annotation"), &mainWindow);
+	auto cropAction = new QAction(QStringLiteral("Crop"), &mainWindow);
+	auto scaleAction = new QAction(QStringLiteral("Scale"), &mainWindow);
+	auto modifyCanvasAction = new QAction(QStringLiteral("Modify Canvas"), &mainWindow);
 	mainWindow.connect(annotationAction, &QAction::triggered, kImageAnnotator, &KImageAnnotator::showAnnotator);
 	mainWindow.connect(cropAction, &QAction::triggered, kImageAnnotator, &KImageAnnotator::showCropper);
 	mainWindow.connect(scaleAction, &QAction::triggered, kImageAnnotator, &KImageAnnotator::showScaler);

--- a/src/common/constants/Constants.h
+++ b/src/common/constants/Constants.h
@@ -39,7 +39,7 @@ const QSize MenuItemIconSize(20, 20);
 
 const QSize SettingsWidgetIconSize(20, 20);
 
-const QColor HoverColor(QLatin1Literal("#add8e6"));
+const QColor HoverColor(0xad, 0xd8, 0xe6); // "#add8e6"
 
 } // namespace Constants
 

--- a/src/gui/annotator/AnnotationSettings.cpp
+++ b/src/gui/annotator/AnnotationSettings.cpp
@@ -97,24 +97,24 @@ Tools AnnotationSettings::toolType() const
 
 void AnnotationSettings::initGui()
 {
-	mColorPicker->setIcon(IconLoader::load(QLatin1String("color.svg")));
+	mColorPicker->setIcon(IconLoader::load(QStringLiteral("color.svg")));
 	mColorPicker->setToolTip(tr("Color"));
 
-	mTextColorPicker->setIcon(IconLoader::load(QLatin1String("textColor.svg")));
+	mTextColorPicker->setIcon(IconLoader::load(QStringLiteral("textColor.svg")));
 	mTextColorPicker->setToolTip(tr("Text Color"));
 
-	mWidthPicker->setIcon(IconLoader::load(QLatin1String("width.svg")));
+	mWidthPicker->setIcon(IconLoader::load(QStringLiteral("width.svg")));
 	mWidthPicker->setToolTip(tr("Width"));
 
-	mFontSizePicker->setIcon(IconLoader::load(QLatin1String("fontSize.svg")));
+	mFontSizePicker->setIcon(IconLoader::load(QStringLiteral("fontSize.svg")));
 	mFontSizePicker->setToolTip(tr("Font Size"));
 	mFontSizePicker->setRange(10, 40);
-	
-	mNumberToolSeedPicker->setIcon(IconLoader::load(QLatin1Literal("number.svg")));
+
+	mNumberToolSeedPicker->setIcon(IconLoader::load(QStringLiteral("number.svg")));
 	mNumberToolSeedPicker->setToolTip(tr("Number Seed"));
 	mNumberToolSeedPicker->setRange(1, 100);
 
-	mObfuscateFactorPicker->setIcon(IconLoader::load(QLatin1String("obfuscateFactor.svg")));
+	mObfuscateFactorPicker->setIcon(IconLoader::load(QStringLiteral("obfuscateFactor.svg")));
 	mObfuscateFactorPicker->setToolTip(tr("Obfuscation Factor"));
 	mObfuscateFactorPicker->setRange(1, 20);
 

--- a/src/widgets/FillModePicker.cpp
+++ b/src/widgets/FillModePicker.cpp
@@ -61,13 +61,13 @@ void FillModePicker::initGui()
 {
 	mLayout->setContentsMargins(0, 0, 0, 0);
 
-	auto icon = IconLoader::load(QLatin1String("fillType.svg"));
+	auto icon = IconLoader::load(QStringLiteral("fillType.svg"));
 	mLabel->setPixmap(icon.pixmap(Constants::SettingsWidgetIconSize));
 	mLabel->setToolTip(tr("Border And Fill Visibility"));
 
-	insertItem(FillModes::BorderAndFill, QLatin1String("fillType_borderAndFill.svg"), tr("Border and Fill"));
-	insertItem(FillModes::BorderAndNoFill, QLatin1String("fillType_borderAndNoFill.svg"), tr("Border and No Fill"));
-	insertItem(FillModes::NoBorderAndNoFill, QLatin1String("fillType_noBorderAndNoFill.svg"), tr("No Border and No Fill"));
+	insertItem(FillModes::BorderAndFill, QStringLiteral("fillType_borderAndFill.svg"), tr("Border and Fill"));
+	insertItem(FillModes::BorderAndNoFill, QStringLiteral("fillType_borderAndNoFill.svg"), tr("Border and No Fill"));
+	insertItem(FillModes::NoBorderAndNoFill, QStringLiteral("fillType_noBorderAndNoFill.svg"), tr("No Border and No Fill"));
 
 	mToolButton->setFixedSize(Constants::SettingsWidgetSize);
 	mToolButton->setIconSize(Constants::ToolButtonIconSize);

--- a/src/widgets/ImageEffectPicker.cpp
+++ b/src/widgets/ImageEffectPicker.cpp
@@ -51,14 +51,14 @@ void ImageEffectPicker::initGui()
 {
 	mLayout->setContentsMargins(0, 0, 0, 0);
 
-	auto icon = IconLoader::load(QLatin1String("effect.svg"));
+	auto icon = IconLoader::load(QStringLiteral("effect.svg"));
 	mLabel->setPixmap(icon.pixmap(Constants::SettingsWidgetIconSize));
 	mLabel->setToolTip(tr("Image Effects"));
 
-	insertItem(ImageEffects::NoEffect, QLatin1String("noImageEffect.svg"), tr("No Effect"));
-	insertItem(ImageEffects::DropShadow, QLatin1String("dropShadowImageEffect.svg"), tr("Drop Shadow"));
-	insertItem(ImageEffects::Grayscale, QLatin1String("grayscaleImageEffect.svg"), tr("Grayscale"));
-	insertItem(ImageEffects::Border, QLatin1String("borderImageEffect.svg"), tr("Border"));
+	insertItem(ImageEffects::NoEffect, QStringLiteral("noImageEffect.svg"), tr("No Effect"));
+	insertItem(ImageEffects::DropShadow, QStringLiteral("dropShadowImageEffect.svg"), tr("Drop Shadow"));
+	insertItem(ImageEffects::Grayscale, QStringLiteral("grayscaleImageEffect.svg"), tr("Grayscale"));
+	insertItem(ImageEffects::Border, QStringLiteral("borderImageEffect.svg"), tr("Border"));
 
 	mToolButton->setFixedSize(Constants::SettingsWidgetSize);
 	mToolButton->setIconSize(Constants::ToolButtonIconSize);

--- a/src/widgets/StickerPicker.cpp
+++ b/src/widgets/StickerPicker.cpp
@@ -51,7 +51,7 @@ void StickerPicker::init()
 {
 	mLayout->setContentsMargins(0, 0, 0, 0);
 
-	auto icon = IconLoader::load(QLatin1String("sticker.svg"));
+	auto icon = IconLoader::load(QStringLiteral("sticker.svg"));
 	mLabel->setPixmap(icon.pixmap(Constants::SettingsWidgetIconSize));
 	mLabel->setToolTip(tr("Sticker"));
 

--- a/src/widgets/ToolPicker.cpp
+++ b/src/widgets/ToolPicker.cpp
@@ -55,75 +55,75 @@ void ToolPicker::initGui()
 	mActionGroup = new QActionGroup(this);
 	connect(mActionGroup, &QActionGroup::triggered, this, &ToolPicker::actionTriggered);
 
-	auto action = createAction(tr("Select"), IconLoader::load(QLatin1String("select.svg")), Qt::Key_S, Tools::Select);
+	auto action = createAction(tr("Select"), IconLoader::load(QStringLiteral("select.svg")), Qt::Key_S, Tools::Select);
 	auto button = createButton(action);
 	mLayout->addWidget(button, 0, 0);
 
-	action = createAction(tr("Duplicate"), IconLoader::load(QLatin1Literal("duplicate.svg")), Qt::Key_U, Tools::Duplicate);
+	action = createAction(tr("Duplicate"), IconLoader::load(QStringLiteral("duplicate.svg")), Qt::Key_U, Tools::Duplicate);
 	button = createButton(action);
 	mLayout->addWidget(button, 0, 1);
 
 	auto menu = new QMenu();
-	action = createAction(tr("Arrow"), IconLoader::load(QLatin1String("arrow.svg")), Qt::Key_A, Tools::Arrow);
+	action = createAction(tr("Arrow"), IconLoader::load(QStringLiteral("arrow.svg")), Qt::Key_A, Tools::Arrow);
 	menu->addAction(action);
-	action = createAction(tr("Double Arrow"), IconLoader::load(QLatin1String("doubleArrow.svg")), Qt::Key_D, Tools::DoubleArrow);
+	action = createAction(tr("Double Arrow"), IconLoader::load(QStringLiteral("doubleArrow.svg")), Qt::Key_D, Tools::DoubleArrow);
 	menu->addAction(action);
-	action = createAction(tr("Line"), IconLoader::load(QLatin1String("line.svg")), Qt::Key_L, Tools::Line);
+	action = createAction(tr("Line"), IconLoader::load(QStringLiteral("line.svg")), Qt::Key_L, Tools::Line);
 	menu->addAction(action);
 	button = createButton(menu);
 	mLayout->addWidget(button, 1, 0);
 
-	action = createAction(tr("Pen"), IconLoader::load(QLatin1String("pen.svg")), Qt::Key_P, Tools::Pen);
+	action = createAction(tr("Pen"), IconLoader::load(QStringLiteral("pen.svg")), Qt::Key_P, Tools::Pen);
 	button = createButton(action);
 	mLayout->addWidget(button, 1, 1);
 
 	menu = new QMenu();
-	action = createAction(tr("Marker Rectangle"), IconLoader::load(QLatin1String("markerRect.svg")), Qt::Key_J, Tools::MarkerRect);
+	action = createAction(tr("Marker Rectangle"), IconLoader::load(QStringLiteral("markerRect.svg")), Qt::Key_J, Tools::MarkerRect);
 	menu->addAction(action);
-	action = createAction(tr("Marker Ellipse"), IconLoader::load(QLatin1String("markerEllipse.svg")), Qt::Key_K, Tools::MarkerEllipse);
+	action = createAction(tr("Marker Ellipse"), IconLoader::load(QStringLiteral("markerEllipse.svg")), Qt::Key_K, Tools::MarkerEllipse);
 	menu->addAction(action);
-	action = createAction(tr("Marker Pen"), IconLoader::load(QLatin1String("markerPen.svg")), Qt::Key_M, Tools::MarkerPen);
+	action = createAction(tr("Marker Pen"), IconLoader::load(QStringLiteral("markerPen.svg")), Qt::Key_M, Tools::MarkerPen);
 	menu->addAction(action);
 	button = createButton(menu);
 	mLayout->addWidget(button, 2, 0);
 
 	menu = new QMenu();
-	action = createAction(tr("Text"), IconLoader::load(QLatin1String("text.svg")), Qt::Key_T, Tools::Text);
+	action = createAction(tr("Text"), IconLoader::load(QStringLiteral("text.svg")), Qt::Key_T, Tools::Text);
 	menu->addAction(action);
-	action = createAction(tr("Text Pointer"), IconLoader::load(QLatin1String("textPointer.svg")), Qt::Key_C, Tools::TextPointer);
+	action = createAction(tr("Text Pointer"), IconLoader::load(QStringLiteral("textPointer.svg")), Qt::Key_C, Tools::TextPointer);
 	menu->addAction(action);
-	action = createAction(tr("Text Arrow"), IconLoader::load(QLatin1String("textArrow.svg")), Qt::Key_H, Tools::TextArrow);
+	action = createAction(tr("Text Arrow"), IconLoader::load(QStringLiteral("textArrow.svg")), Qt::Key_H, Tools::TextArrow);
 	menu->addAction(action);
 	button = createButton(menu);
 	mLayout->addWidget(button, 2, 1);
 
 	menu = new QMenu();
-	action = createAction(tr("Number"), IconLoader::load(QLatin1String("number.svg")), Qt::Key_N, Tools::Number);
+	action = createAction(tr("Number"), IconLoader::load(QStringLiteral("number.svg")), Qt::Key_N, Tools::Number);
 	menu->addAction(action);
-	action = createAction(tr("Number Pointer"), IconLoader::load(QLatin1String("numberPointer.svg")), Qt::Key_O, Tools::NumberPointer);
+	action = createAction(tr("Number Pointer"), IconLoader::load(QStringLiteral("numberPointer.svg")), Qt::Key_O, Tools::NumberPointer);
 	menu->addAction(action);
-	action = createAction(tr("Number Arrow"), IconLoader::load(QLatin1String("numberArrow.svg")), Qt::Key_W, Tools::NumberArrow);
+	action = createAction(tr("Number Arrow"), IconLoader::load(QStringLiteral("numberArrow.svg")), Qt::Key_W, Tools::NumberArrow);
 	menu->addAction(action);
 	button = createButton(menu);
 	mLayout->addWidget(button, 3, 0);
 
 	menu = new QMenu();
-	action = createAction(tr("Blur"), IconLoader::load(QLatin1String("blur.svg")), Qt::Key_B, Tools::Blur);
+	action = createAction(tr("Blur"), IconLoader::load(QStringLiteral("blur.svg")), Qt::Key_B, Tools::Blur);
 	menu->addAction(action);
-	action = createAction(tr("Pixelate"), IconLoader::load(QLatin1String("pixelate.svg")), Qt::Key_X, Tools::Pixelate);
+	action = createAction(tr("Pixelate"), IconLoader::load(QStringLiteral("pixelate.svg")), Qt::Key_X, Tools::Pixelate);
 	menu->addAction(action);
 	button = createButton(menu);
 	mLayout->addWidget(button, 3, 1);
 
 	menu = new QMenu();
-	action = createAction(tr("Rectangle"), IconLoader::load(QLatin1String("rect.svg")), Qt::Key_R, Tools::Rect);
+	action = createAction(tr("Rectangle"), IconLoader::load(QStringLiteral("rect.svg")), Qt::Key_R, Tools::Rect);
 	menu->addAction(action);
-	action = createAction(tr("Ellipse"), IconLoader::load(QLatin1String("ellipse.svg")), Qt::Key_E, Tools::Ellipse);
+	action = createAction(tr("Ellipse"), IconLoader::load(QStringLiteral("ellipse.svg")), Qt::Key_E, Tools::Ellipse);
 	menu->addAction(action);
 	button = createButton(menu);
 	mLayout->addWidget(button, 4, 0);
 
-	action = createAction(tr("Sticker"), IconLoader::load(QLatin1String("sticker.svg")), Qt::Key_I, Tools::Sticker);
+	action = createAction(tr("Sticker"), IconLoader::load(QStringLiteral("sticker.svg")), Qt::Key_I, Tools::Sticker);
 	button = createButton(action);
 	mLayout->addWidget(button, 4, 1);
 

--- a/src/widgets/ZoomIndicator.cpp
+++ b/src/widgets/ZoomIndicator.cpp
@@ -34,7 +34,7 @@ void ZoomIndicator::init()
 {
 	mLayout->setContentsMargins(0, 0, 0, 0);
 
-	auto icon = IconLoader::load(QLatin1String("zoom.svg"));
+	auto icon = IconLoader::load(QStringLiteral("zoom.svg"));
 	mLabel->setPixmap(icon.pixmap(SettingsWidgetIconSize));
 	mLabel->setToolTip(tr("Zoom Level"));
 


### PR DESCRIPTION
This mostly replaces QLatin1Literal -- which is deprecated in Qt5.15 at least -- by QStringLiteral. In most cases, the API being called uses a const QString& anyway (or in the case of IconLoader::load, a QString by value) so there is an additional conversion from QLatin1String to QString anyway.

This follows the advice from https://woboq.com/blog/qstringliteral.html .

Not all uses of QLatin1String are addressed; `StickerPicker::addDefaultStickers()` for instance builds a QStringList from QLatin1Strings and I can't tell if that really matters in the face of `-O2` settings for most compilers. Un-optimized there's a lot of extra constructions and conversions, though.

One use of QLatin1Literal was being used to parse the string *"#add8e6"* to RGB values; I've done that by hand instead.