### PR TITLE
Horizontally align text inside spin box.

### DIFF
--- a/src/widgets/CustomSpinBox.cpp
+++ b/src/widgets/CustomSpinBox.cpp
@@ -23,6 +23,7 @@ namespace kImageAnnotator {
 
 kImageAnnotator::CustomSpinBox::CustomSpinBox(QWidget *parent) : QSpinBox(parent)
 {
+	setAlignment(Qt::AlignHCenter);
 	connect(this, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &CustomSpinBox::valueChanged);
 }
 


### PR DESCRIPTION
Hello, this is my first commit.
This patch fixes an inconsistency with other KDE apps by horizontally aligning the text inside the spin box.
See https://bugs.kde.org/show_bug.cgi?id=432166

Before | After

![before](https://user-images.githubusercontent.com/4569753/105968827-da0bf400-6087-11eb-9009-38b80ca0744a.png)![after](https://user-images.githubusercontent.com/4569753/105968813-d6786d00-6087-11eb-8f2c-27df59fb1c71.png)

