### PR TITLE
Allow applying graphics effect to annotations of type duplicate

### DIFF
--- a/src/annotations/core/AnnotationArea.cpp
+++ b/src/annotations/core/AnnotationArea.cpp
@@ -190,9 +190,7 @@ void AnnotationArea::imageEffectChanged(ImageEffects effect)
 	mImage->setGraphicsEffect(graphicsEffect);
 	for (auto &item : *mItems) {
 		auto itemGraphicsEffect = ImageEffectFactory::create(effect);
-		if (item->allowsApplyingImageEffects()) {
-			item->setGraphicsEffect(itemGraphicsEffect);
-		}
+		item->applyImageEffect(itemGraphicsEffect);
 	}
 }
 

--- a/src/annotations/core/AnnotationArea.cpp
+++ b/src/annotations/core/AnnotationArea.cpp
@@ -310,6 +310,8 @@ void AnnotationArea::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 
 void AnnotationArea::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 {
+	finishDrawingItem(event->scenePos());
+
 	mItemModifier->handleSelectionAt(event->scenePos(), mItems, mKeyHelper->isControlPressed());
 	auto selectedItems = mItemModifier->selectedItems();
 
@@ -317,7 +319,7 @@ void AnnotationArea::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 	auto isMenuOverItem = !selectedItems.isEmpty();
 	contextMenu.setOverItem(isMenuOverItem);
 	contextMenu.setPastEnabled(!mItemCopier->isEmpty());
-    contextMenu.setEditVisible(selectedEditableItem() != nullptr);
+	contextMenu.setEditVisible(selectedEditableItem() != nullptr);
 	AnnotationItemArranger itemArranger(selectedItems, mItems);
 	connect(&itemArranger, &AnnotationItemArranger::newCommand, mUndoStack, &UndoStack::push);
 	connect(&contextMenu, &AnnotationContextMenu::bringToFront, &itemArranger, &AnnotationItemArranger::bringToFront);

--- a/src/annotations/core/AnnotationArea.cpp
+++ b/src/annotations/core/AnnotationArea.cpp
@@ -188,6 +188,12 @@ void AnnotationArea::imageEffectChanged(ImageEffects effect)
 {
 	auto graphicsEffect = ImageEffectFactory::create(effect);
 	mImage->setGraphicsEffect(graphicsEffect);
+	for (auto &item : *mItems) {
+		auto itemGraphicsEffect = ImageEffectFactory::create(effect);
+		if (item->allowsApplyingImageEffects()) {
+			item->setGraphicsEffect(itemGraphicsEffect);
+		}
+	}
 }
 
 void AnnotationArea::setCanvasRect(const QRectF &rect)
@@ -277,7 +283,7 @@ void AnnotationArea::finishDrawingItem(const QPointF &pos)
 		mCurrentItem->finish();
 
 		if (mCurrentItem->requiresSelectionAfterCreation()) {
-			mItemModifier->handleSelectionAt(pos, mItems, false);
+			mItemModifier->handleSelectionAt(mCurrentItem->boundingRect().topLeft(), mItems, false);
 		}
 
 		mCurrentItem = nullptr;
@@ -306,8 +312,6 @@ void AnnotationArea::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 
 void AnnotationArea::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 {
-	finishDrawingItem(event->scenePos());
-
 	mItemModifier->handleSelectionAt(event->scenePos(), mItems, mKeyHelper->isControlPressed());
 	auto selectedItems = mItemModifier->selectedItems();
 

--- a/src/annotations/items/AbstractAnnotationItem.cpp
+++ b/src/annotations/items/AbstractAnnotationItem.cpp
@@ -193,9 +193,9 @@ void AbstractAnnotationItem::setProperties(const PropertiesPtr &properties)
 	updateProperties(properties);
 }
 
-bool AbstractAnnotationItem::allowsApplyingImageEffects() const
+void AbstractAnnotationItem::applyImageEffect(QGraphicsEffect *effect)
 {
-	return false;
+	Q_UNUSED(effect);
 }
 
 void AbstractAnnotationItem::addShadowIfRequired()

--- a/src/annotations/items/AbstractAnnotationItem.cpp
+++ b/src/annotations/items/AbstractAnnotationItem.cpp
@@ -193,6 +193,11 @@ void AbstractAnnotationItem::setProperties(const PropertiesPtr &properties)
 	updateProperties(properties);
 }
 
+bool AbstractAnnotationItem::allowsApplyingImageEffects() const
+{
+	return false;
+}
+
 void AbstractAnnotationItem::addShadowIfRequired()
 {
 	if (mProperties->shadowEnabled()) {

--- a/src/annotations/items/AbstractAnnotationItem.h
+++ b/src/annotations/items/AbstractAnnotationItem.h
@@ -52,7 +52,7 @@ public:
 	virtual void scale(qreal sx, qreal sy) = 0;
 	virtual Tools toolType() const = 0;
 	virtual void setProperties(const PropertiesPtr &properties);
-	virtual bool allowsApplyingImageEffects() const;
+	virtual void applyImageEffect(QGraphicsEffect *effect);
 
 protected:
 	void setShape(QPainterPath &newShape);

--- a/src/annotations/items/AbstractAnnotationItem.h
+++ b/src/annotations/items/AbstractAnnotationItem.h
@@ -52,6 +52,7 @@ public:
 	virtual void scale(qreal sx, qreal sy) = 0;
 	virtual Tools toolType() const = 0;
 	virtual void setProperties(const PropertiesPtr &properties);
+	virtual bool allowsApplyingImageEffects() const;
 
 protected:
 	void setShape(QPainterPath &newShape);

--- a/src/annotations/items/AnnotationDuplicate.cpp
+++ b/src/annotations/items/AnnotationDuplicate.cpp
@@ -36,6 +36,11 @@ bool AnnotationDuplicate::requiresSelectionAfterCreation() const
 	return true;
 }
 
+bool AnnotationDuplicate::allowsApplyingImageEffects() const
+{
+	return true;
+}
+
 void AnnotationDuplicate::updateShape()
 {
 	QPainterPath path;
@@ -54,6 +59,9 @@ void AnnotationDuplicate::captureScene()
 {
 	auto parentScene = scene();
 	if (parentScene != nullptr) {
+		*mRect = parentScene->sceneRect().intersected(*mRect);
+		updateShape();
+
 		mSceneSelectionImage = QImage(mRect->normalized().size().toSize(), QImage::Format_ARGB32_Premultiplied);
 		mSceneSelectionImage.fill(Qt::transparent);
 		QPainter imagePainter(&mSceneSelectionImage);

--- a/src/annotations/items/AnnotationDuplicate.cpp
+++ b/src/annotations/items/AnnotationDuplicate.cpp
@@ -36,9 +36,9 @@ bool AnnotationDuplicate::requiresSelectionAfterCreation() const
 	return true;
 }
 
-bool AnnotationDuplicate::allowsApplyingImageEffects() const
+void AnnotationDuplicate::applyImageEffect(QGraphicsEffect *effect)
 {
-	return true;
+	setGraphicsEffect(effect);
 }
 
 void AnnotationDuplicate::updateShape()

--- a/src/annotations/items/AnnotationDuplicate.h
+++ b/src/annotations/items/AnnotationDuplicate.h
@@ -34,6 +34,7 @@ public:
 	Tools toolType() const override;
 	void finish() override;
 	bool requiresSelectionAfterCreation() const override;
+	bool allowsApplyingImageEffects() const override;
 
 protected:
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *style, QWidget *widget) override;

--- a/src/annotations/items/AnnotationDuplicate.h
+++ b/src/annotations/items/AnnotationDuplicate.h
@@ -34,7 +34,7 @@ public:
 	Tools toolType() const override;
 	void finish() override;
 	bool requiresSelectionAfterCreation() const override;
-	bool allowsApplyingImageEffects() const override;
+	void applyImageEffect(QGraphicsEffect *effect) override;
 
 protected:
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *style, QWidget *widget) override;


### PR DESCRIPTION
Fixes https://github.com/ksnip/kImageAnnotator/issues/213

* all graphic effects applied will also apply to duplicates
* duplicates will be resized to sceneRect
  * otherwise, when applying GrayscaleEffect, the transparent portion of the duplicate annotation would turn black
* selection point will be based on actual item boundingRect, instead of last mouse position
  * this is because, when creating a duplicate annotation, if the last mouse position is outside the scene rect, that part will be clipped (duplicates are clipped to size of sceneRect intersection) and the selection would not work