### PR TITLE
Allow the ToolPicker to have a scrollbar

### DIFF
--- a/src/gui/annotator/docks/AbstractAnnotationDockWidgetContent.h
+++ b/src/gui/annotator/docks/AbstractAnnotationDockWidgetContent.h
@@ -23,6 +23,7 @@
 #include <QWidget>
 #include <QBoxLayout>
 #include <QList>
+#include <QScrollArea>
 
 #include "src/widgets/misc/AbstractExpandingWidget.h"
 

--- a/src/gui/annotator/settings/AnnotationToolSelection.cpp
+++ b/src/gui/annotator/settings/AnnotationToolSelection.cpp
@@ -23,9 +23,13 @@ namespace kImageAnnotator {
 
 AnnotationToolSelection::AnnotationToolSelection() :
 	mMainLayout(new QVBoxLayout),
-	mToolPicker(new ToolPicker(this))
+	mToolPicker(new ToolPicker(this)),
+	mScrollareaToolPicker(new QScrollArea)
 {
-	mMainLayout->addWidget(mToolPicker);
+	mScrollareaToolPicker->setWidgetResizable(true);
+	mScrollareaToolPicker->setWidget(mToolPicker);
+	mScrollareaToolPicker->setFrameShape(QFrame::NoFrame);
+	mMainLayout->addWidget(mScrollareaToolPicker);
 	mMainLayout->setContentsMargins(0, 0, 0, 0);
 
 	setLayout(mMainLayout);

--- a/src/gui/annotator/settings/AnnotationToolSelection.h
+++ b/src/gui/annotator/settings/AnnotationToolSelection.h
@@ -42,6 +42,7 @@ signals:
 private:
 	QVBoxLayout *mMainLayout;
 	ToolPicker *mToolPicker;
+	QScrollArea *mScrollareaToolPicker;
 };
 
 } // namespace kImageAnnotator


### PR DESCRIPTION
The ToolPicker is never fully visible when the kImageAnnotator window is smaller than the ToolPicker area.
Occurs especially when used embedded within an program, like Spectacle, which makes it almost
impossible for the user to know if there are more tools to choose from. Instead of going by pure
luck/intuition and resizing the main window, in this example the window of Spectacle, showing a scrollbar
when the window is too small to show all tools by default gives a hint to the user that there are more tools available.
The scroll bar would be only shown when needed, not always :)

![1108_213417](https://user-images.githubusercontent.com/7177449/140815633-87650740-308e-41bd-9cb2-389cdf54e952.png)

How it currently looks within Spectacle:

![1108_213657](https://user-images.githubusercontent.com/7177449/140815652-86b79921-1c02-42ce-9d5d-e7bfc6b05042.png)