### PR TITLE
Add option to hide or show the controls widget when needed/wanted

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 	kImageAnnotator->setTabBarAutoHide(true);
 	kImageAnnotator->addTab(pixmap, QLatin1String("image1"), QLatin1String("image1"));
 	kImageAnnotator->addTab(pixmap, QLatin1String("image2"), QLatin1String("image2"));
-    kImageAnnotator->showControlsWidget();
+	kImageAnnotator->setControlsWidgetVisible(true);
 	kImageAnnotator->adjustSize();
 
 	QMainWindow mainWindow;

--- a/include/kImageAnnotator/KImageAnnotator.h
+++ b/include/kImageAnnotator/KImageAnnotator.h
@@ -49,7 +49,7 @@ public:
 	void showScaler();
 	void showRotator();
 	void showCanvasModifier();
-	void showControlsWidget();
+	void setControlsWidgetVisible(bool enabled);
 
 public Q_SLOTS:
 	void loadImage(const QPixmap &pixmap);

--- a/src/gui/CoreView.cpp
+++ b/src/gui/CoreView.cpp
@@ -132,9 +132,9 @@ void CoreView::showCanvasModifier()
 	mModifyCanvasWidget->activate(mAnnotationWidget->annotationArea());
 }
 
-void CoreView::showControlsWidget()
+void CoreView::setControlsWidgetVisible(bool enabled)
 {
-	mAnnotationWidget->showControlsWidget();
+	mAnnotationWidget->setControlsWidgetVisible(enabled);
 }
 
 void CoreView::setSettingsCollapsed(bool isCollapsed)

--- a/src/gui/CoreView.h
+++ b/src/gui/CoreView.h
@@ -62,7 +62,7 @@ public slots:
 	void showScaler();
 	void showRotator();
 	void showCanvasModifier();
-	void showControlsWidget();
+	void setControlsWidgetVisible(bool enabled);
 	void setSettingsCollapsed(bool isCollapsed);
 	void setTabBarAutoHide(bool enabled);
 	void setStickers(const QStringList &stickerPaths, bool keepDefault);

--- a/src/gui/KImageAnnotator.cpp
+++ b/src/gui/KImageAnnotator.cpp
@@ -226,10 +226,10 @@ void KImageAnnotator::showCanvasModifier()
 	d->mCoreView.showCanvasModifier();
 }
 
-void KImageAnnotator::showControlsWidget()
+void KImageAnnotator::setControlsWidgetVisible(bool enabled)
 {
 	Q_D(KImageAnnotator);
-	d->mCoreView.showControlsWidget();
+	d->mCoreView.setControlsWidgetVisible(enabled);
 }
 
 void KImageAnnotator::setSettingsCollapsed(bool isCollapsed)

--- a/src/gui/annotator/AnnotationWidget.cpp
+++ b/src/gui/annotator/AnnotationWidget.cpp
@@ -60,11 +60,6 @@ void AnnotationWidget::initGui()
 	insertDockWidget(Qt::TopDockWidgetArea, mItemSettings);
 	insertDockWidget(Qt::BottomDockWidgetArea, mGeneralSettings);
 	insertDockWidget(Qt::BottomDockWidgetArea, mImageSettings);
-	insertDockWidget(Qt::BottomDockWidgetArea, mControlsWidget);
-
-	// hide the last inserted DockWidget (mControlsWidget) since we want to show it only if needed using setControlsWidgetVisible(true)
-	mControlsDockWidget = mDockWidgets.last();
-	removeDockWidget(mControlsDockWidget);
 
 	setFocusPolicy(Qt::ClickFocus);
 
@@ -84,11 +79,12 @@ void AnnotationWidget::initGui()
 	connect(qApp, &QCoreApplication::aboutToQuit, this, &AnnotationWidget::persistDockWidgets);
 }
 
-void AnnotationWidget::insertDockWidget(Qt::DockWidgetArea area, AbstractAnnotationDockWidgetContent *content)
+AnnotationDockWidget *AnnotationWidget::insertDockWidget(Qt::DockWidgetArea area, AbstractAnnotationDockWidgetContent *content)
 {
 	auto dockWidget = new AnnotationDockWidget(content);
 	mDockWidgets.append(dockWidget);
 	addDockWidget(area, dockWidget);
+	return dockWidget;
 }
 
 QImage AnnotationWidget::image() const
@@ -199,7 +195,9 @@ void AnnotationWidget::setSettingsCollapsed(bool isCollapsed)
 void AnnotationWidget::setControlsWidgetVisible(bool enabled)
 {
 	if (enabled) {
-		restoreDockWidget(mControlsDockWidget);
+		if (mControlsDockWidget == nullptr) {
+			mControlsDockWidget = insertDockWidget(Qt::BottomDockWidgetArea, mControlsWidget);
+		}
 		restoreDockWidgetsState();
 	} else {
 		removeDockWidget(mControlsDockWidget);

--- a/src/gui/annotator/AnnotationWidget.cpp
+++ b/src/gui/annotator/AnnotationWidget.cpp
@@ -29,7 +29,8 @@ AnnotationWidget::AnnotationWidget(Config *config) :
 	mImageSettings(new AnnotationImageSettings),
 	mControlsWidget(new AnnotationControlsWidget),
 	mSettingsAdapter(new AnnotationSettingsAdapter(mGeneralSettings, mItemSettings, mToolSelection, mImageSettings, mControlsWidget, config)),
-	mAnnotationTabWidget(new AnnotationTabWidget(config, mSettingsAdapter))
+	mAnnotationTabWidget(new AnnotationTabWidget(config, mSettingsAdapter)),
+	mControlsDockWidget(nullptr)
 {
 	initGui();
 	restoreDockWidgets();

--- a/src/gui/annotator/AnnotationWidget.cpp
+++ b/src/gui/annotator/AnnotationWidget.cpp
@@ -41,7 +41,7 @@ AnnotationWidget::~AnnotationWidget()
 	delete mItemSettings;
 	delete mToolSelection;
 	delete mImageSettings;
-    delete mControlsWidget;
+	delete mControlsWidget;
 	delete mGeneralSettings;
 }
 
@@ -59,6 +59,11 @@ void AnnotationWidget::initGui()
 	insertDockWidget(Qt::TopDockWidgetArea, mItemSettings);
 	insertDockWidget(Qt::BottomDockWidgetArea, mGeneralSettings);
 	insertDockWidget(Qt::BottomDockWidgetArea, mImageSettings);
+	insertDockWidget(Qt::BottomDockWidgetArea, mControlsWidget);
+
+	// hide the last inserted DockWidget (mControlsWidget) since we want to show it only if needed using setControlsWidgetVisible(true)
+	mControlsDockWidget = mDockWidgets.last();
+	removeDockWidget(mControlsDockWidget);
 
 	setFocusPolicy(Qt::ClickFocus);
 
@@ -190,10 +195,14 @@ void AnnotationWidget::setSettingsCollapsed(bool isCollapsed)
 	}
 }
 
-void AnnotationWidget::showControlsWidget()
+void AnnotationWidget::setControlsWidgetVisible(bool enabled)
 {
-	insertDockWidget(Qt::BottomDockWidgetArea, mControlsWidget);
-	restoreDockWidgets();
+	if (enabled) {
+		restoreDockWidget(mControlsDockWidget);
+		restoreDockWidgets();
+	} else {
+		removeDockWidget(mControlsDockWidget);
+	}
 }
 
 void AnnotationWidget::persistDockWidgets()

--- a/src/gui/annotator/AnnotationWidget.cpp
+++ b/src/gui/annotator/AnnotationWidget.cpp
@@ -33,7 +33,7 @@ AnnotationWidget::AnnotationWidget(Config *config) :
 	mControlsDockWidget(nullptr)
 {
 	initGui();
-	restoreDockWidgets();
+	restoreDockWidgetsState();
 }
 
 AnnotationWidget::~AnnotationWidget()
@@ -200,7 +200,7 @@ void AnnotationWidget::setControlsWidgetVisible(bool enabled)
 {
 	if (enabled) {
 		restoreDockWidget(mControlsDockWidget);
-		restoreDockWidgets();
+		restoreDockWidgetsState();
 	} else {
 		removeDockWidget(mControlsDockWidget);
 	}
@@ -211,7 +211,7 @@ void AnnotationWidget::persistDockWidgets()
 	mConfig->setAnnotatorDockWidgetsState(saveState());
 }
 
-void AnnotationWidget::restoreDockWidgets()
+void AnnotationWidget::restoreDockWidgetsState()
 {
 	restoreState(mConfig->annotatorDockWidgetsState());
 }

--- a/src/gui/annotator/AnnotationWidget.h
+++ b/src/gui/annotator/AnnotationWidget.h
@@ -58,7 +58,7 @@ public:
 	void setStickers(const QStringList &stickerPaths, bool keepDefault);
 	void addTabContextMenuActions(const QList<QAction*> & actions);
 	void setSettingsCollapsed(bool isCollapsed);
-	void showControlsWidget();
+	void setControlsWidgetVisible(bool enabled);
 
 signals:
 	void imageChanged() const;
@@ -81,6 +81,7 @@ private:
 	AnnotationSettingsAdapter *mSettingsAdapter;
 	AnnotationTabWidget *mAnnotationTabWidget;
 	QList<AnnotationDockWidget*> mDockWidgets;
+    AnnotationDockWidget *mControlsDockWidget;
 
 	void initGui();
 	void insertDockWidget(Qt::DockWidgetArea area, AbstractAnnotationDockWidgetContent *content);

--- a/src/gui/annotator/AnnotationWidget.h
+++ b/src/gui/annotator/AnnotationWidget.h
@@ -81,7 +81,7 @@ private:
 	AnnotationSettingsAdapter *mSettingsAdapter;
 	AnnotationTabWidget *mAnnotationTabWidget;
 	QList<AnnotationDockWidget*> mDockWidgets;
-    AnnotationDockWidget *mControlsDockWidget;
+	AnnotationDockWidget *mControlsDockWidget;
 
 	void initGui();
 	void insertDockWidget(Qt::DockWidgetArea area, AbstractAnnotationDockWidgetContent *content);

--- a/src/gui/annotator/AnnotationWidget.h
+++ b/src/gui/annotator/AnnotationWidget.h
@@ -84,7 +84,7 @@ private:
 	AnnotationDockWidget *mControlsDockWidget;
 
 	void initGui();
-	void insertDockWidget(Qt::DockWidgetArea area, AbstractAnnotationDockWidgetContent *content);
+	AnnotationDockWidget *insertDockWidget(Qt::DockWidgetArea area, AbstractAnnotationDockWidgetContent *content);
 
 private slots:
 	void persistDockWidgets();

--- a/src/gui/annotator/AnnotationWidget.h
+++ b/src/gui/annotator/AnnotationWidget.h
@@ -88,7 +88,7 @@ private:
 
 private slots:
 	void persistDockWidgets();
-	void restoreDockWidgets();
+	void restoreDockWidgetsState();
 	void scaleTriggered() const;
 	void cropTriggered() const;
 	void rotateTriggered() const;


### PR DESCRIPTION
Instead of only allowing it once and keep it visible until program is closed,
add a function setControlsWidgetVisible(true/false) that allows to hide/show
the controls widget 'on the fly'.

setControlsWidgetVisible(true) -> shows the controls widget
setControlsWidgetVisible(false) -> hides the controls widget

As requested in https://github.com/ksnip/kImageAnnotator/pull/263#issuecomment-982065035