### PR TITLE
Switch to tab before displaying save prompt when triggering 'Close' action

### DIFF
--- a/src/gui/annotator/tabs/AnnotationTabCloser.cpp
+++ b/src/gui/annotator/tabs/AnnotationTabCloser.cpp
@@ -30,7 +30,9 @@ AnnotationTabCloser::AnnotationTabCloser(QTabWidget *parent) :
 
 void AnnotationTabCloser::closeTabTriggered(int index)
 {
-	mTabWidget->tabCloseRequested(getValidIndex(index));
+	const auto selectedTabIndex = getValidIndex(index);
+	mTabWidget->setCurrentIndex(selectedTabIndex);
+	mTabWidget->tabCloseRequested(selectedTabIndex);
 }
 
 void AnnotationTabCloser::closeOtherTabsTriggered(int index)


### PR DESCRIPTION
Missed this one in the previous commit; only handled the other close actions.
Implements: https://github.com/ksnip/ksnip/issues/750
Addition to: https://github.com/ksnip/kImageAnnotator/pull/268