### PR TITLE
Remove double entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * New: Cut out vertical or horizontal slice of an image. ([#236](https://github.com/ksnip/kImageAnnotator/issues/236))
 * New: Middle-click on tab header closes tab. ([#280](https://github.com/ksnip/kImageAnnotator/issues/280))
 * New: Add button to fit image into current view. ([#281](https://github.com/ksnip/kImageAnnotator/issues/281))
-* New: Add button to fit image into current view. ([#281](https://github.com/ksnip/kImageAnnotator/issues/281))
 * New: Allow changing item opacity. ([#110](https://github.com/ksnip/kImageAnnotator/issues/110))
 * New: Add support for RGBA colors with transparency. ([#119](https://github.com/ksnip/kImageAnnotator/issues/119))
 * Fixed: Adding image effect does not send image change notification. ([#283](https://github.com/ksnip/kImageAnnotator/issues/283))


### PR DESCRIPTION
following entry is twice in the changelog:

New: Add button to fit image into current view. (https://github.com/ksnip/kImageAnnotator/issues/281)