### PR TITLE
Lousy fix for a lousy problem with unnecessary scrollbars

### DIFF
--- a/src/gui/annotator/AnnotationWidget.cpp
+++ b/src/gui/annotator/AnnotationWidget.cpp
@@ -103,6 +103,11 @@ QImage AnnotationWidget::imageAt(int index) const
 void AnnotationWidget::loadImage(const QPixmap &pixmap)
 {
 	auto currentAnnotationArea = annotationArea();
+	removeTab(0);
+	addTab(pixmap, QString(), QString());
+	return;
+
+	// unreachable code:
 	if(currentAnnotationArea == nullptr) {
 		addTab(pixmap, QString(), QString());
 	} else {


### PR DESCRIPTION
This will get a proper commit msg when I come up with a better/proper fix.

Reproducing this Bug:
disable Tabs in Ksnip.
take a big screenshot
take a smaller one. 
Smaller one has scroll bars even tho it fits within the area.

I tried twiddling around with https://github.com/ksnip/kImageAnnotator/blob/master/src/annotations/core/AnnotationArea.cpp#L100 but whatever I add or change there, it just doesn't work. Took help from https://doc.qt.io/qt-5/qgraphicsscene.html , but nope :/
So this is so far the best I can come up with.

Spectacle also suffers from this bug: take screenshot, annotate. Take smaller screenshot, annotate. Et voila, unnecessary scrollbars visible.

unreachable code is kept, just to easier follow up.

Do you have any idea or hint?