### PR TITLE
Revert Custom Scaling Handling for KDE / QT

### DIFF
--- a/src/common/provider/ScaledSizeProvider.cpp
+++ b/src/common/provider/ScaledSizeProvider.cpp
@@ -55,21 +55,24 @@ qreal ScaledSizeProvider::scaleFactor()
 qreal ScaledSizeProvider::getScaleFactor()
 {
 #if defined(__linux__)
-    DesktopEnvironmentChecker desktopEnvironmentChecker;
-	auto environment = desktopEnvironmentChecker.getDesktopEnvironment();
-
-	if (environment == DesktopEnvironmentType::Gnome) {
+	if(isGnomeEnvironment()) {
 		auto screen = QApplication::primaryScreen();
 		auto logicalDotsPerInch = (int) screen->logicalDotsPerInch();
 		auto physicalDotsPerInch = (int) screen->physicalDotsPerInch();
 		return (qreal)logicalDotsPerInch / (qreal)physicalDotsPerInch;
-	} else if (environment == DesktopEnvironmentType::Kde) {
-		auto screen = QApplication::primaryScreen();
-		return screen->devicePixelRatio();
 	}
 #endif
 
 	return 1;
 }
+
+#if defined(__linux__)
+bool ScaledSizeProvider::isGnomeEnvironment()
+{
+	auto currentDesktop = QString(qgetenv("XDG_CURRENT_DESKTOP"));
+	return currentDesktop.contains(QLatin1String("gnome"), Qt::CaseInsensitive)
+		|| currentDesktop.contains(QLatin1String("unity"), Qt::CaseInsensitive);
+}
+#endif
 
 } // namespace kImageAnnotator

--- a/src/common/provider/ScaledSizeProvider.h
+++ b/src/common/provider/ScaledSizeProvider.h
@@ -46,6 +46,10 @@ private:
 	static qreal scaleFactor();
 	static qreal getScaleFactor();
 
+#if defined(__linux__)
+	static bool isGnomeEnvironment();
+#endif
+
 	ScaledSizeProvider() = default;
 	~ScaledSizeProvider() = default;
 };


### PR DESCRIPTION
As mentioned in number #326, scaling has been broken ever since #302. This pull request aims to fix that by reverting that commit. If there are any concerns then do let me know, but as Nicholas Fella mentioned QT already handles scaling.