### PR TITLE
Fix result images being rescaled on HDPI monitors

### DIFF
--- a/src/annotations/core/AnnotationArea.cpp
+++ b/src/annotations/core/AnnotationArea.cpp
@@ -107,17 +107,13 @@ QImage AnnotationArea::image()
 	mItemModifier->clear();
 	
 	setSceneRect(canvasRect());
-	auto scaleFactor = mDevicePixelRatioScaler->scaleFactor();
-	auto sceneRect = this->sceneRect();
-	auto scaledSceneSize = sceneRect.size().toSize() * scaleFactor;
-	auto scaledSceneRect = QRectF(sceneRect.topLeft(), scaledSceneSize);
-	QImage image(scaledSceneSize, QImage::Format_ARGB32_Premultiplied);
+	auto sceneRect = this->sceneRect().toRect();
+	QImage image(sceneRect.size(), QImage::Format_ARGB32_Premultiplied);
 	image.fill(mCanvasColor);
-	image.setDevicePixelRatio(scaleFactor);
 
 	QPainter painter(&image);
 	painter.setRenderHint(QPainter::Antialiasing);
-	render(&painter, QRectF(), scaledSceneRect);
+	render(&painter, QRectF(), sceneRect);
 
 	setSceneRect(QRect()); // Reset scene rect
 

--- a/tests/annotations/core/AnnotationAreaTest.cpp
+++ b/tests/annotations/core/AnnotationAreaTest.cpp
@@ -47,7 +47,7 @@ void AnnotationAreaTest::ExportAsImage_Should_ExportEmptyImage_When_NoImageSet()
 	QCOMPARE(QImage(), resultImage);
 }
 
-void AnnotationAreaTest::ExportAsImage_Should_ExportScaledImage_When_ScalingEnabled()
+void AnnotationAreaTest::ExportAsImage_Should_ExportUnscaledImage_When_ScalingEnabled()
 {
 	auto scaleFactor = 1.5;
 	QPixmap pixmap(QSize(400, 400));
@@ -61,9 +61,7 @@ void AnnotationAreaTest::ExportAsImage_Should_ExportScaledImage_When_ScalingEnab
 
 	auto resultImage = annotationArea.image();
 
-	auto expectedImage = pixmap.scaled(pixmap.size() * scaleFactor).toImage().convertToFormat(QImage::Format_ARGB32_Premultiplied);
-	expectedImage.setDevicePixelRatio(scaleFactor);
-	QCOMPARE(resultImage, expectedImage);
+	QCOMPARE(resultImage, pixmap.toImage());
 }
 
 void AnnotationAreaTest::AddAnnotationItem_Should_AddAnnotationItemToScene()

--- a/tests/annotations/core/AnnotationAreaTest.h
+++ b/tests/annotations/core/AnnotationAreaTest.h
@@ -42,7 +42,7 @@ Q_OBJECT
 private slots:
 	void ExportAsImage_Should_ExportImage_When_ImageSet();
 	void ExportAsImage_Should_ExportEmptyImage_When_NoImageSet();
-	void ExportAsImage_Should_ExportScaledImage_When_ScalingEnabled();
+	void ExportAsImage_Should_ExportUnscaledImage_When_ScalingEnabled();
 	void AddAnnotationItem_Should_AddAnnotationItemToScene();
 	void RemoveAnnotationItem_Should_RemoveAnnotationItemFromScene();
 	void CanvasRect_Should_ReturnRectUnionOfAllItems_When_NoCanvasRectSet();


### PR DESCRIPTION
Currently, in Gwenview (which uses kImageAnnotator), when using the annotate feature on devices with Display Scaling enabled, the resulting image gets rescaled as well; e.g. if one starts annotating a 10x10 image on a 125%-scaled monitor, they would get a 20x20 image after annotating: [KDE bug 485066](https://bugs.kde.org/show_bug.cgi?id=485066)

I considered changing the pixel ratio of the image coming from Gwenview in https://github.com/KDE/gwenview/blob/fa8a60a7988504feafe78c4d39c2ad362b31ad56/lib/annotate/annotatedialog.cpp#L53 to match the device pixel ratio instead, however doing so ends up adding a border of white pixels around odd-sized images (e.g. 11x11 becomes 12x12), and also doubles annotation sizes (e.g. 3-width pencil tool ends up taking 4 pixels).

I also tested this change with `ksnip` (with the xdg-portal based grabber), and it seemed to work fine as long as "scale generic wayland screenshots" is enabled.

BTW, this PR was made during a [livestream, starting at 00:11:50](https://watch.bojidar-bg.dev/w/4CpB1zAKesJGY8HSAdkGpE?start=11m50s). You can see me testing with ksnip around [01:30:21](https://watch.bojidar-bg.dev/w/4CpB1zAKesJGY8HSAdkGpE?start=1h30m21s).