### PR TITLE
Fix low quality image export on high-DPI displays

### DIFF
--- a/src/annotations/core/AnnotationArea.cpp
+++ b/src/annotations/core/AnnotationArea.cpp
@@ -108,7 +108,9 @@ QImage AnnotationArea::image()
 	
 	setSceneRect(canvasRect());
 	auto sceneRect = this->sceneRect().toRect();
-	QImage image(sceneRect.size(), QImage::Format_ARGB32_Premultiplied);
+	auto dpr = mDevicePixelRatioScaler->scaleFactor();
+	QImage image(sceneRect.size() * dpr, QImage::Format_ARGB32_Premultiplied);
+	image.setDevicePixelRatio(dpr);
 	image.fill(mCanvasColor);
 
 	QPainter painter(&image);


### PR DESCRIPTION
On Qt6 with high-DPI scaling enabled by default, AnnotationArea::image() was creating the output QImage at logical size instead of physical pixel size. This caused downscaling of the rendered image, resulting in blurry output when saving to file or copying to clipboard.

Account for devicePixelRatio when creating the output image so it matches the full resolution of the background pixmap.